### PR TITLE
Resolve dependencies as nested graph

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule ".conche/packages/Spectre"]
 	path = .conche/packages/Spectre
 	url = https://github.com/kylef/Spectre
+[submodule "ConcheSpecs/fixtures/resolver_integration_specs"]
+	path = ConcheSpecs/fixtures/resolver_integration_specs
+	url = https://github.com/CocoaPods/Resolver-Integration-Specs

--- a/Conche.podspec.json
+++ b/Conche.podspec.json
@@ -26,7 +26,8 @@
   "test_spec": {
     "source_files": "ConcheSpecs/*.swift",
     "dependencies": {
-      "Spectre": [ "~> 0.4.1" ]
+      "Spectre": [ "~> 0.4.1" ],
+      "PathKit": [ "~> 0.5.0" ]
     }
   }
 }

--- a/Conche/Dependency.swift
+++ b/Conche/Dependency.swift
@@ -9,6 +9,7 @@ public enum RequirementOperator : String, CustomStringConvertible {
   case LessThanEqual = "<="
   case MoreThan = ">"
   case MoreThanEqual = ">="
+  case NotEqual = "!="
 
   public var description: String {
     return rawValue
@@ -28,6 +29,8 @@ public enum RequirementOperator : String, CustomStringConvertible {
       return lhs > rhs
     case .MoreThanEqual:
       return lhs >= rhs
+    case .NotEqual:
+      return lhs != rhs
     }
   }
 }

--- a/Conche/DependencyResolver.swift
+++ b/Conche/DependencyResolver.swift
@@ -67,7 +67,7 @@ public func resolve(dependency: Dependency, sources: [SourceType], dependencies:
     do {
       let resolution = try specification.dependencies.map {
         try resolve($0, sources: sources, dependencies: dependencies + specification.dependencies)
-      }.uniq()
+      }.sort().uniq()
       let graph = DependencyGraph(root: specification, dependencies: resolution)
       if graph.hasCircularReference() {
         throw DependencyResolverError.CircularDependency(graph)
@@ -112,6 +112,11 @@ extension CollectionType where Generator.Element == DependencyGraph {
     }
   }
 
+  /// Sorts graphs by name and version, lowest first
+  func sort() -> [Generator.Element] {
+    return sort { $0.root.name < $1.root.name && $0.root.version < $1.root.version }
+  }
+
   /// Iterates over the specifications returning the first
   /// duplicated specification by name
   func detectDuplicate() -> Generator.Element? {
@@ -137,7 +142,7 @@ extension CollectionType where Generator.Element == Specification {
     return filter { seen.updateValue(true, forKey: $0.description) == nil }
   }
 
-  /// Sorts specifications by name and version
+  /// Sorts specifications by name and version, highest first
   func sort() -> [Generator.Element] {
     return sort { $0.name >= $1.name && $0.version >= $1.version }
   }

--- a/Conche/DependencyResolver.swift
+++ b/Conche/DependencyResolver.swift
@@ -114,7 +114,7 @@ extension CollectionType where Generator.Element == DependencyGraph {
 
   /// Sorts graphs by name and version, lowest first
   func sort() -> [Generator.Element] {
-    return sort { $0.root.name < $1.root.name && $0.root.version < $1.root.version }
+    return sort { $0.root.name < $1.root.name }
   }
 
   /// Iterates over the specifications returning the first

--- a/Conche/DependencyResolverError.swift
+++ b/Conche/DependencyResolverError.swift
@@ -1,6 +1,6 @@
 public enum DependencyResolverError : ErrorType, Equatable, CustomStringConvertible {
   case NoSuchDependency(Dependency)
-  case CircularDependency(String, requiredBy: [Specification])
+  case CircularDependency(DependencyGraph)
   case Conflict(String, requiredBy: [Dependency])
 
   public var description: String {
@@ -9,8 +9,8 @@ public enum DependencyResolverError : ErrorType, Equatable, CustomStringConverti
       return "Dependency '\(dependency)' not found."
     case .Conflict(let dependencyName, let requirements):
       return "Dependency '\(dependencyName)' requires conflicting versions from requirements: \(requirements)."
-    case .CircularDependency(let dependencyName, let requirements):
-      return "Dependency '\(dependencyName)' resolved to a cycle using requirements: \(requirements)"
+    case .CircularDependency(let graph):
+      return "Dependency '\(graph.root.name)' resolved to a cycle using requirements: \(graph.flatten())"
     }
   }
 }
@@ -23,8 +23,8 @@ public func == (lhs: DependencyResolverError, rhs: DependencyResolverError) -> B
     return lhsDependency == rhsDependency
   case let (.Conflict(lhsName, lhsRequirements), .Conflict(rhsName, rhsRequirements)):
     return lhsName == rhsName && lhsRequirements == rhsRequirements
-  case let (.CircularDependency(lhsName, lhsSpecifications), .CircularDependency(rhsName, rhsSpecifications)):
-    return lhsName == rhsName && lhsSpecifications.count == rhsSpecifications.count
+  case let (.CircularDependency(lhsGraph), .CircularDependency(rhsGraph)):
+    return lhsGraph ~= rhsGraph
   default:
     return false
   }

--- a/Conche/DependencyResolverError.swift
+++ b/Conche/DependencyResolverError.swift
@@ -1,12 +1,12 @@
 public enum DependencyResolverError : ErrorType, Equatable, CustomStringConvertible {
-  case CircularDependency(DependencyGraph)
+  case CircularDependency(String, requiredBy: [Dependency])
   case Conflict(String, requiredBy: [Dependency])
   case NoSuchDependency(Dependency)
 
   public var description: String {
     switch self {
-    case .CircularDependency(let graph):
-      return "Dependency '\(graph.root.name)' resolved to a cycle using requirements: \(graph.flatten())"
+    case .CircularDependency(let dependencyName, let requirements):
+      return "Dependency '\(dependencyName)' could not be resolved due to circular references between: \(requirements)."
     case .Conflict(let dependencyName, let requirements):
       return "Dependency '\(dependencyName)' requires conflicting versions from requirements: \(requirements)."
     case .NoSuchDependency(let dependency):
@@ -23,8 +23,8 @@ public func == (lhs: DependencyResolverError, rhs: DependencyResolverError) -> B
     return lhsDependency == rhsDependency
   case let (.Conflict(lhsName, lhsRequirements), .Conflict(rhsName, rhsRequirements)):
     return lhsName == rhsName && lhsRequirements == rhsRequirements
-  case let (.CircularDependency(lhsGraph), .CircularDependency(rhsGraph)):
-    return lhsGraph ~= rhsGraph
+  case let (.CircularDependency(lhsName, lhsRequirements), .CircularDependency(rhsName, rhsRequirements)):
+    return lhsName == rhsName && lhsRequirements == rhsRequirements
   default:
     return false
   }

--- a/Conche/DependencyResolverError.swift
+++ b/Conche/DependencyResolverError.swift
@@ -1,0 +1,31 @@
+public enum DependencyResolverError : ErrorType, Equatable, CustomStringConvertible {
+  case NoSuchDependency(Dependency)
+  case CircularDependency(String, requiredBy: [Specification])
+  case Conflict(String, requiredBy: [Dependency])
+
+  public var description: String {
+    switch self {
+    case .NoSuchDependency(let dependency):
+      return "Dependency '\(dependency)' not found."
+    case .Conflict(let dependencyName, let requirements):
+      return "Dependency '\(dependencyName)' requires conflicting versions from requirements: \(requirements)."
+    case .CircularDependency(let dependencyName, let requirements):
+      return "Dependency '\(dependencyName)' resolved to a cycle using requirements: \(requirements)"
+    }
+  }
+}
+
+/// Returns if to dependency resolver errors are identical
+/// note: Circular dependencies do not correctly check the inner specifications
+public func == (lhs: DependencyResolverError, rhs: DependencyResolverError) -> Bool {
+  switch (lhs, rhs) {
+  case let (.NoSuchDependency(lhsDependency), .NoSuchDependency(rhsDependency)):
+    return lhsDependency == rhsDependency
+  case let (.Conflict(lhsName, lhsRequirements), .Conflict(rhsName, rhsRequirements)):
+    return lhsName == rhsName && lhsRequirements == rhsRequirements
+  case let (.CircularDependency(lhsName, lhsSpecifications), .CircularDependency(rhsName, rhsSpecifications)):
+    return lhsName == rhsName && lhsSpecifications.count == rhsSpecifications.count
+  default:
+    return false
+  }
+}

--- a/Conche/DependencyResolverError.swift
+++ b/Conche/DependencyResolverError.swift
@@ -1,16 +1,16 @@
 public enum DependencyResolverError : ErrorType, Equatable, CustomStringConvertible {
-  case NoSuchDependency(Dependency)
   case CircularDependency(DependencyGraph)
   case Conflict(String, requiredBy: [Dependency])
+  case NoSuchDependency(Dependency)
 
   public var description: String {
     switch self {
-    case .NoSuchDependency(let dependency):
-      return "Dependency '\(dependency)' not found."
-    case .Conflict(let dependencyName, let requirements):
-      return "Dependency '\(dependencyName)' requires conflicting versions from requirements: \(requirements)."
     case .CircularDependency(let graph):
       return "Dependency '\(graph.root.name)' resolved to a cycle using requirements: \(graph.flatten())"
+    case .Conflict(let dependencyName, let requirements):
+      return "Dependency '\(dependencyName)' requires conflicting versions from requirements: \(requirements)."
+    case .NoSuchDependency(let dependency):
+      return "Dependency '\(dependency)' not found."
     }
   }
 }

--- a/ConcheSpecs/DependencyResolverSpec.swift
+++ b/ConcheSpecs/DependencyResolverSpec.swift
@@ -156,9 +156,16 @@ describe("resolve()") {
     ])
 
     $0.it("throws a 'circular reference' error") {
+      let graph = DependencyGraph(root: source.specifications[0], dependencies: [
+        DependencyGraph(root: source.specifications[2], dependencies: [
+          DependencyGraph(root: source.specifications[3], dependencies: [
+            DependencyGraph(root: source.specifications[1], dependencies: [])
+          ])
+        ])
+      ])
       try expect(
         try resolve(depends("Cookie", ["1.0.0"]), sources: [source])
-      ).toThrow(DependencyResolverError.CircularDependency("Cookie", requiredBy: source.specifications))
+      ).toThrow(DependencyResolverError.CircularDependency(graph))
     }
   }
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ LIBS = $(foreach lib,$(DEPENDENCIES),.conche/lib/lib$(lib).dylib)
 SWIFTC := xcrun -sdk macosx swiftc
 SWIFTFLAGS = $(addprefix -l, $(DEPENDENCIES))
 
-SOURCES = Dependency DependencyResolver Downloader Source Specification SpecificationBuilder Task Tasks/SpecificationTask Invoke Version build test
+SOURCES = Dependency DependencyResolver DependencyResolverError Downloader \
+		  Source Specification SpecificationBuilder Task \
+		  Tasks/SpecificationTask Invoke Version build test
 SOURCE_FILES = $(foreach file,$(SOURCES),Conche/$(file).swift)
 
 


### PR DESCRIPTION
## Changes

* Reorganized the resolver components:
  - Added `DependencyGraph`
  - Moved `DependencyResolverError` into its own file
* Improved dependency resolution:
  - Added support for `!=` operator for dependency requirements
  - Improved circular resolution detection
  - Fixed graph sorting bug where dependencies would be in reverse order
* Added and enabled a subset of the CocoaPods shared resolver tests